### PR TITLE
Load review UI from file instead of inline HTML

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -5,7 +5,7 @@ import { open, type GlimpseWindow } from "glimpseui";
 import { createCheckpoint, getRepoRoot } from "./git.js";
 import { composeFeedback } from "./prompt.js";
 import type { HostMessage, ReviewCheckpoint, WindowMessage } from "./types.js";
-import { loadReviewHtml } from "./ui.js";
+import { reviewHtmlPath } from "./ui.js";
 import { WorkspaceModel } from "./workspace.js";
 
 export const CHECKPOINT_ENTRY = "review-loop/checkpoint";
@@ -65,8 +65,19 @@ export class ReviewController {
     await this.model.refresh();
     await this.startWatcher();
 
-    const window = open(loadReviewHtml(), { width: 1480, height: 920, title: "Review Loop" });
+    const window = open("<!doctype html><title>Loading Review Loop...</title>", {
+      width: 1480,
+      height: 920,
+      title: "Review Loop",
+    });
     this.window = window;
+    window.once("ready", () => {
+      try {
+        window.loadFile(reviewHtmlPath());
+      } catch (error) {
+        ctx.ui.notify(`Review Loop failed to load its UI: ${error instanceof Error ? error.message : String(error)}`, "error");
+      }
+    });
     window.on("message", (value) => {
       const message = parseMessage(value);
       if (message != null) void this.handleMessage(message, ctx);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const reviewHtmlUrl = new URL("../web/dist/index.html", import.meta.url);
 
 export function loadReviewHtml(): string {
   return readFileSync(reviewHtmlUrl, "utf8");
+}
+
+export function reviewHtmlPath(): string {
+  return fileURLToPath(reviewHtmlUrl);
 }


### PR DESCRIPTION
This changes Review Loop to load its web UI from the built
 web/dist/index.html file instead of passing the full HTML inline to
 open().

 Why:
 - On Linux, when glimpseui falls back to its Chromium backend, opening the
   large self-contained Review Loop HTML inline can result in a blank window.
 - Loading the built file from disk avoids that problem and worked correctly in
   local testing.

 What changed:
 - Added a helper to resolve the built review HTML file path.
 - Open the window first, then load the UI with window.loadFile(...) on
   ready.

 This is a small change that should make the extension more robust on Linux
 setups using the Chromium fallback backend.