### PR TITLE
fix: ignore nested dependency trees in watcher

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -10,6 +10,10 @@ import { WorkspaceModel } from "./workspace.js";
 
 export const CHECKPOINT_ENTRY = "review-loop/checkpoint";
 
+export function isIgnoredWatchPath(repoRoot: string, path: string): boolean {
+  return relative(repoRoot, path).split(sep).some((part) => part === ".git" || part === "node_modules");
+}
+
 function isCheckpoint(value: unknown): value is ReviewCheckpoint {
   if (value == null || typeof value !== "object") return false;
   const item = value as Partial<ReviewCheckpoint>;
@@ -93,11 +97,9 @@ export class ReviewController {
   private async startWatcher(): Promise<void> {
     this.watcher = watch(this.repoRoot, {
       ignoreInitial: true,
-      ignored: (path) => {
-        const rel = relative(this.repoRoot, path);
-        return rel === ".git" || rel.startsWith(`.git${sep}`) || rel === "node_modules" || rel.startsWith(`node_modules${sep}`);
-      },
+      ignored: (path) => isIgnoredWatchPath(this.repoRoot, path),
     });
+    this.watcher.on("error", () => {});
     this.watcher.on("all", (_event, path) => {
       const repoPath = this.toRepoPath(path);
       if (repoPath == null) return;

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import test from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isIgnoredWatchPath } from "../src/controller.js";
 import { composeFeedback } from "../src/prompt.js";
 import { createCheckpoint, decodeStored, parsePorcelainPaths, scanAgainstCheckpoint } from "../src/git.js";
 import { WorkspaceModel } from "../src/workspace.js";
@@ -30,6 +31,12 @@ function fakePi(): ExtensionAPI {
 async function git(cwd: string, ...args: string[]): Promise<void> {
   await execFileAsync("git", args, { cwd });
 }
+
+test("ignores generated dependency and git trees at any depth", () => {
+  assert.equal(isIgnoredWatchPath("/repo", "/repo/packages/app/node_modules/pkg/file.js"), true);
+  assert.equal(isIgnoredWatchPath("/repo", "/repo/packages/app/.git/index"), true);
+  assert.equal(isIgnoredWatchPath("/repo", "/repo/src/file.ts"), false);
+});
 
 test("parses porcelain paths including renames", () => {
   const output = " M src/a.ts\0R  src/new.ts\0src/old.ts\0?? new file.ts\0";


### PR DESCRIPTION
Fixes #5 

## Summary

Prevent `/diff-review` from crashing Pi when reviewing repositories that contain nested `node_modules` or `.git`
 directories.

## Problem

The file watcher only ignored `.git` and `node_modules` when they were located directly under the repository root.

In repositories containing nested dependency trees or embedded Git repositories, Chokidar could create too many file
 watchers and eventually emit:

```text
 EMFILE: too many open files, watch
```

Because the watcher error was unhandled, the error terminated Pi.

## Changes

- Ignore .git and node_modules directories at any depth.
- Handle watcher errors so they do not become uncaught exceptions.
- Add regression tests for nested ignored directories.